### PR TITLE
supports TextInputType.url in url field

### DIFF
--- a/lib/com/hydrologis/smash/import_export_plugins/utils/gss_2022_utilities.dart
+++ b/lib/com/hydrologis/smash/import_export_plugins/utils/gss_2022_utilities.dart
@@ -532,6 +532,7 @@ class Gss2022SettingsState extends State<Gss2022Settings>
                                         .settings_serverUrlStartWithHttp; //"Server url needs to start with http or https."
                                   }
                                 },
+                                keyboardType: TextInputType.url,
                               )),
                         ],
                       ),

--- a/lib/com/hydrologis/smash/import_export_plugins/utils/gss_utilities.dart
+++ b/lib/com/hydrologis/smash/import_export_plugins/utils/gss_utilities.dart
@@ -638,6 +638,7 @@ class GssSettingsState extends State<GssSettings> with AfterLayoutMixin {
                                         .settings_serverUrlStartWithHttp; //"Server url needs to start with http or https."
                                   }
                                 },
+                                keyboardType: TextInputType.url,
                               )),
                         ],
                       ),

--- a/lib/com/hydrologis/smash/import_export_plugins/utils/gtt_utilities.dart
+++ b/lib/com/hydrologis/smash/import_export_plugins/utils/gtt_utilities.dart
@@ -586,6 +586,7 @@ class GttSettingsState extends State<GttSettings> with AfterLayoutMixin {
                                         .settings_serverUrlStartWithHttp; //"Server url needs to start with http or https."
                                   }
                                 },
+                                keyboardType: TextInputType.url,
                               )),
                         ],
                       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     # path: ../smashlibs/
     git:
       url: https://github.com/moovida/smashlibs.git
-      ref: ecc1d3e
+      ref: 5da9602
 
   
   # apache 2


### PR DESCRIPTION
- supports TextInputType.url in 3 fields
- bump smashlib to current version